### PR TITLE
Add API + refactor service names

### DIFF
--- a/alembic/README.md
+++ b/alembic/README.md
@@ -27,6 +27,24 @@ docker compose up importer  # to import the data, after the import step, the
 # container is shut down
 ```
 
+Access the database at `localhost:5432` with a PostGIS enabled client
+(e.g. [`pgAdmin`](https://www.pgadmin.org/)).
+
+### 3️⃣ [Optional] API
+
+Using [`pg_tileserv`](https://github.com/CrunchyData/pg_tileserv), an API
+is provided to access the data. This service is optional, but could provide
+an entrypoint for further applications.
+To start the service, run:
+
+```bash
+docker compose up -d api
+```
+
+Navigate to [http://localhost:7800](http://localhost:7800) to preview
+the endpoints. `public.landslides_view` provides a comprehensive view of the
+landslide data.
+
 ---
 
 ## For developers
@@ -81,18 +99,4 @@ Reset to base, with:
 
 ```bash
 alembic downgrade base
-```
-
-Enter the container within `psql`:
-
-```bash
-docker exec -it landslides-db psql -U postgres -d landslides
-```
-
-Show tables, get first 10 rows and exit:
-
-```bash
-\dt
-SELECT * FROM landslides LIMIT 10;
-\q
 ```

--- a/alembic/README.md
+++ b/alembic/README.md
@@ -9,7 +9,7 @@ First add an `.env` file at the root of the project with following content:
 ```env
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=mysecretpassword  # TODO choose a new password
-POSTGRES_HOST=postgis  # PostGIS service in docker compose
+POSTGRES_HOST=db  # PostGIS service in docker compose
 POSTGRES_PORT=5432
 POSTGRES_DB=landslides
 ```
@@ -22,8 +22,8 @@ With Docker installed, build and start the containers with:
 
 ```bash
 docker compose build
-docker compose up -d postgis  # wait until the db accepts connections
-docker compose up import  # to import the data, after the import step, the
+docker compose up -d db  # wait until the db accepts connections
+docker compose up importer  # to import the data, after the import step, the
 # container is shut down
 ```
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,20 +6,40 @@ services:
       - ./db:/var/lib/postgresql/data
     ports:
       - "5432:5432"
-    env_file: .env
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d landslides"]
       interval: 5s
       timeout: 5s
       retries: 5
+    networks:
+      - landslides-net
 
   # run migrations and import data; exits when done
   importer:
     build: .
+    env_file: .env
     command: bash -c "alembic upgrade head && python import.py"
     volumes:
       - ./data:/app/data
     depends_on:
-      postgis:
+      db:
         condition: service_healthy
+    networks:
+      - landslides-net
+    
+  api:
+    image: pramsey/pg_tileserv:20250131
     env_file: .env
+    environment:
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/landslides
+    ports:
+      - "7800:7800"
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - landslides-net
+
+networks:
+  landslides-net:
+    driver: bridge

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
-  postgis:
+  db:
     image: postgis/postgis:17-3.5
+    env_file: .env
     volumes:
       - ./db:/var/lib/postgresql/data
     ports:
@@ -12,7 +13,8 @@ services:
       timeout: 5s
       retries: 5
 
-  import:
+  # run migrations and import data; exits when done
+  importer:
     build: .
     command: bash -c "alembic upgrade head && python import.py"
     volumes:

--- a/helper.py
+++ b/helper.py
@@ -10,4 +10,4 @@ if db_dir.exists() and db_dir.is_dir():
     shutil.rmtree(db_dir)
 
 subprocess.run(["docker", "compose", "build"])
-subprocess.run(["docker", "compose", "up", "postgis", "-d"])
+subprocess.run(["docker", "compose", "up", "db", "-d"])


### PR DESCRIPTION
This PR introduces `pg_tileserv` as a new API service. This service exposes the PostGIS data as a vector tile API and can be used as an entrypoint for further applications.

Additionally, the Docker services have been renamed to better reflect their roles (postgis -> db, import -> importer). The new `pg_tileserv` service is named api.