### PR TITLE
Rename the repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Version `0.2.2`
+
+### 🛠 Dev changes
+
+- Renamed the repository from `landslides-db` to `ocomma-db` to better
+  reflect the project's scope, which extends beyond landslides to all
+  mass-movement phenomena.
+  - Updated the Python package name in `pyproject.toml`.
+  - Updated GitHub links in the documentation.
+  - Renamed the GeoPackage dump file from `landslides-db.gpkg` to
+    `ocomma-db.gpkg`.
+
 ## Version `0.2.1`
 
 ### 🌟 Features

--- a/db-dump/landslides-db.gpkg
+++ b/db-dump/landslides-db.gpkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7adfc7905d472d6c9c613a90cabe63c6ceba3b4c513723bfa30dafce447104df
-size 5668864

--- a/db-dump/ocomma-db.gpkg
+++ b/db-dump/ocomma-db.gpkg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23025a950be72baf9f21a442c36a229005132bdb14772cf586d5c3009ada715f
+size 5689344

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -41,7 +41,7 @@ export default defineConfig({
     ],
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/JakobKlotz/landslides-db' }
+      { icon: 'github', link: 'https://github.com/JakobKlotz/ocomma-db' }
     ],
 
     footer: {

--- a/docs/intro/about.md
+++ b/docs/intro/about.md
@@ -72,7 +72,7 @@ we provide a ready-to-use GeoPackage file. This is ideal for:
 
 The GeoPackage dump contains a single table with all events and is located in
 the repository's
-[`db-dump/`](https://github.com/JakobKlotz/landslides-db/tree/main/db-dump)
+[`db-dump/`](https://github.com/JakobKlotz/ocomma-db/tree/main/db-dump)
 directory. Simply download and open it in your favorite GIS application.
 
 :::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "landslides-db"
-version = "0.2.1"
+name = "ocomma-db"
+version = "0.2.2"
 description = "Open Collection of Mass Movements in Austria"
 readme = "README.md"
 authors = [

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -7,7 +7,7 @@ from db.utils import create_db_session
 
 out_path = Path("./db-dump")
 out_path.mkdir(parents=True, exist_ok=True)
-out_file = out_path / "landslides-db.gpkg"
+out_file = out_path / "ocomma-db.gpkg"
 
 # always remove file (overwriting a GeoPackage leads to issues!)
 out_file.unlink(missing_ok=True)

--- a/src/db/utils.py
+++ b/src/db/utils.py
@@ -90,7 +90,7 @@ def create_source_from_metadata(metadata: Dict[str, Any]) -> Sources:
 
 def import_version() -> None:
     """Add the current package version to a dedicated table."""
-    __version__ = version("landslides-db")
+    __version__ = version("ocomma-db")
 
     Session = create_db_session()  # noqa: N806
     with Session() as session:

--- a/uv.lock
+++ b/uv.lock
@@ -487,43 +487,6 @@ wheels = [
 ]
 
 [[package]]
-name = "landslides-db"
-version = "0.2.1"
-source = { editable = "." }
-dependencies = [
-    { name = "alembic" },
-    { name = "geoalchemy2" },
-    { name = "geopandas" },
-    { name = "psycopg", extra = ["binary"] },
-    { name = "python-dotenv" },
-    { name = "sqlalchemy" },
-    { name = "typer" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "contextily" },
-    { name = "ipykernel" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "alembic", specifier = ">=1.18.4" },
-    { name = "geoalchemy2", specifier = ">=0.18.0" },
-    { name = "geopandas", specifier = ">=1.1.1" },
-    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.10" },
-    { name = "python-dotenv", specifier = ">=1.1.1" },
-    { name = "sqlalchemy", specifier = ">=2.0.43" },
-    { name = "typer", specifier = ">=0.20.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "contextily", specifier = ">=1.6.2" },
-    { name = "ipykernel", specifier = ">=6.30.1" },
-]
-
-[[package]]
 name = "mako"
 version = "1.3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -680,6 +643,43 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/8e/3ab61a730bdbbc201bb245a71102aa609f0008b9ed15255500a99cd7f780/numpy-2.3.3-cp313-cp313t-win32.whl", hash = "sha256:a333b4ed33d8dc2b373cc955ca57babc00cd6f9009991d9edc5ddbc1bac36bcd", size = 6442776, upload-time = "2025-09-09T15:57:45.793Z" },
     { url = "https://files.pythonhosted.org/packages/1c/3a/e22b766b11f6030dc2decdeff5c2fb1610768055603f9f3be88b6d192fb2/numpy-2.3.3-cp313-cp313t-win_amd64.whl", hash = "sha256:4384a169c4d8f97195980815d6fcad04933a7e1ab3b530921c3fef7a1c63426d", size = 12927281, upload-time = "2025-09-09T15:57:47.492Z" },
     { url = "https://files.pythonhosted.org/packages/7b/42/c2e2bc48c5e9b2a83423f99733950fbefd86f165b468a3d85d52b30bf782/numpy-2.3.3-cp313-cp313t-win_arm64.whl", hash = "sha256:75370986cc0bc66f4ce5110ad35aae6d182cc4ce6433c40ad151f53690130bf1", size = 10265275, upload-time = "2025-09-09T15:57:49.647Z" },
+]
+
+[[package]]
+name = "ocomma-db"
+version = "0.2.2"
+source = { editable = "." }
+dependencies = [
+    { name = "alembic" },
+    { name = "geoalchemy2" },
+    { name = "geopandas" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "python-dotenv" },
+    { name = "sqlalchemy" },
+    { name = "typer" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "contextily" },
+    { name = "ipykernel" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "alembic", specifier = ">=1.18.4" },
+    { name = "geoalchemy2", specifier = ">=0.18.0" },
+    { name = "geopandas", specifier = ">=1.1.1" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2.10" },
+    { name = "python-dotenv", specifier = ">=1.1.1" },
+    { name = "sqlalchemy", specifier = ">=2.0.43" },
+    { name = "typer", specifier = ">=0.20.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "contextily", specifier = ">=1.6.2" },
+    { name = "ipykernel", specifier = ">=6.30.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Renamed the repository from `landslides-db` to `ocomma-db` to better
  reflect the project's scope, which extends beyond landslides to all
  mass-movement phenomena.
  - Updated the Python package name in `pyproject.toml`.
  - Updated GitHub links in the documentation.
  - Renamed the GeoPackage dump file from `landslides-db.gpkg` to
    `ocomma-db.gpkg`.